### PR TITLE
Fix dnsmas-stack.yml

### DIFF
--- a/dnsmasq-stack.yml
+++ b/dnsmasq-stack.yml
@@ -1,5 +1,5 @@
 dnsmasq:
   cap_add:
-    - CAP_NET_ADMIN
+    - NET_ADMIN
   image: 'imj0sh/dockercloud-dnsmasq'
   restart: always


### PR DESCRIPTION
As-was the service won't start and gives the following error:
ERROR: service-dc-dnsmasq-1: linux spec capabilities: Unknown capability to add: "CAP_CAP_NET_ADMIN"